### PR TITLE
ZIMBRA-93: DB upgrade script for search history

### DIFF
--- a/src/db/migration/migrate20170829-SearchHistory.pl
+++ b/src/db/migration/migrate20170829-SearchHistory.pl
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2006, 2007, 2008, 2009, 2010, 2013, 2014, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+
+use strict;
+use Migrate;
+my $concurrent = 10;
+
+Migrate::verifySchemaVersion(108);
+createSearchHistoryTables();
+addSearchIdCheckpointColumn();
+Migrate::updateSchemaVersion(108, 109);
+exit(0);
+
+#####################
+
+sub createSearchHistoryTables($) {
+  my ($group) = @_;
+  my @groups = Migrate::getMailboxGroups();
+  my @sql = ();
+  foreach my $group (@groups) {
+    my $sql = <<_SQL_;
+CREATE TABLE IF NOT EXISTS $group.searches (
+mailbox_id       INTEGER UNSIGNED NOT NULL,
+id               INTEGER UNSIGNED NOT NULL,
+search           VARCHAR(255),
+status           TINYINT NOT NULL DEFAULT 0,
+last_search_date DATETIME,
+
+PRIMARY KEY (mailbox_id, id),
+INDEX i_search (mailbox_id, search),
+CONSTRAINT fk_searches_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+_SQL_
+    push(@sql,$sql);
+  }
+  Migrate::runSqlParallel($concurrent,@sql);
+  my @sql = ();
+  foreach my $group (@groups) {
+    my $sql = <<_SQL_; 
+CREATE TABLE IF NOT EXISTS $group.search_history (
+mailbox_id    INTEGER UNSIGNED NOT NULL,
+search_id     INTEGER UNSIGNED NOT NULL,
+date          DATETIME NOT NULL,
+
+CONSTRAINT fk_search_history_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE,
+CONSTRAINT fk_search_id FOREIGN KEY (mailbox_id, search_id) REFERENCES $group.searches(mailbox_id, id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+_SQL_
+    push(@sql,$sql);
+  }
+  Migrate::runSqlParallel($concurrent,@sql);
+}
+
+sub addSearchIdCheckpointColumn($) {
+  my @sql = ();
+  my $sql = <<_SQL_;
+ALTER TABLE zimbra.mailbox
+ADD COLUMN search_id_checkpoint INTEGER DEFAULT 0 NOT NULL AFTER itemcache_checkpoint;
+_SQL_
+  Migrate::runSql($sql);
+}

--- a/src/db/mysql-cluster/db.sql
+++ b/src/db/mysql-cluster/db.sql
@@ -123,6 +123,7 @@ CREATE TABLE mailbox (
    version             VARCHAR(16),
    last_purge_at       INTEGER UNSIGNED NOT NULL DEFAULT 0,
    itemcache_checkpoint INTEGER UNSIGNED NOT NULL DEFAULT 0,
+   search_id_checkpoint INTEGER UNSIGNED NOT NULL DEFAULT 0,
 
    UNIQUE INDEX i_account_id (account_id),
    INDEX i_index_volume_id (index_volume_id),

--- a/src/db/mysql/create_database.sql
+++ b/src/db/mysql/create_database.sql
@@ -1,7 +1,7 @@
 --
 -- ***** BEGIN LICENSE BLOCK *****
 -- Zimbra Collaboration Suite Server
--- Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+-- Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Synacor, Inc.
 --
 -- This program is free software: you can redistribute it and/or modify it under
 -- the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -330,4 +330,28 @@ CREATE TABLE IF NOT EXISTS chat.`EVENTMESSAGE` (
   `TIMESTAMP` bigint(20) DEFAULT NULL,
   `MESSAGE` text,
   PRIMARY KEY (`ID`)
+) ENGINE = InnoDB;
+
+
+-- Search History
+
+CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.searches (
+   mailbox_id       INTEGER UNSIGNED NOT NULL,
+   id               INTEGER UNSIGNED NOT NULL, -- ID of the query string
+   search           VARCHAR(255), -- the search query string
+   status           TINYINT NOT NULL DEFAULT 0, -- status of the saved search prompt
+   last_search_date DATETIME, -- timestamp of the last time this was searched
+
+   PRIMARY KEY (mailbox_id, id),
+   INDEX i_search (mailbox_id, search), -- for checking existence
+   CONSTRAINT fk_searches_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.search_history (
+   mailbox_id    INTEGER UNSIGNED NOT NULL,
+   search_id     INTEGER UNSIGNED NOT NULL,
+   date          DATETIME NOT NULL,
+
+   CONSTRAINT fk_search_history_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE,
+   CONSTRAINT fk_search_id FOREIGN KEY (mailbox_id, search_id) REFERENCES ${DATABASE_NAME}.searches(mailbox_id, id) ON DELETE CASCADE
 ) ENGINE = InnoDB;

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -123,6 +123,7 @@ CREATE TABLE mailbox (
    version             VARCHAR(16),
    last_purge_at       INTEGER UNSIGNED NOT NULL DEFAULT 0,
    itemcache_checkpoint       INTEGER UNSIGNED NOT NULL DEFAULT 0,
+   search_id_checkpoint INTEGER DEFAULT 0 NOT NULL;
 
    UNIQUE INDEX i_account_id (account_id),
    INDEX i_index_volume_id (index_volume_id),


### PR DESCRIPTION
Database upgrade script that does three things:
1. Adds a new `searches` table to each mailbox group
2. Adds a new `search_history` table to each mailbox group with a foreign key constraint on `searches`
3. Adds a new `search_id_checkpoint` column to the `zimbra.mailbox` database

This was tested by temporarily modifying zmsetup.pl to call zmupgrade::runSchemaUpgrade outside of an actual ZCS installation.
