### PR TITLE
zcs-8670: database changes to support abq

### DIFF
--- a/src/db/migration/migrate20200219-MobileDevices.pl
+++ b/src/db/migration/migrate20200219-MobileDevices.pl
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2020 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+use strict;
+use Migrate;
+
+Migrate::verifySchemaVersion(111);
+
+my $sqlStmt = <<_SQL_;
+
+ALTER TABLE zimbra.`MOBILE_DEVICES`
+ADD `ADDED_TO_QUARANTINE` BOOLEAN DEFAULT 0,
+ADD `QUARANTINE_STATUS` VARCHAR(64) NULL;
+
+_SQL_
+
+Migrate::runSql($sqlStmt);
+
+Migrate::updateSchemaVersion(111, 112);
+
+exit(0);

--- a/src/db/mysql-cluster/db.sql
+++ b/src/db/mysql-cluster/db.sql
@@ -243,6 +243,8 @@ CREATE TABLE mobile_devices (
    phone_number        VARCHAR(64),
    unapproved_appl_list TEXT NULL,
    approved_appl_list   TEXT NULL,
+   added_to_quarantine  BOOLEAN DEFAULT 0,
+   quarantine_status    VARCHAR(64) NULL,
    
    PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -243,6 +243,8 @@ CREATE TABLE mobile_devices (
    phone_number        VARCHAR(64),
    unapproved_appl_list TEXT NULL,
    approved_appl_list   TEXT NULL,
+   added_to_quarantine  BOOLEAN DEFAULT 0,
+   quarantine_status    VARCHAR(64) NULL,
    
    PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,

--- a/src/db/sqlite/db.sql
+++ b/src/db/sqlite/db.sql
@@ -147,6 +147,8 @@ CREATE TABLE mobile_devices (
    phone_number        VARCHAR(64),
    unapproved_appl_list TEXT NULL,
    approved_appl_list   TEXT NULL,
+   added_to_quarantine  BOOLEAN DEFAULT 0,
+   quarantine_status    VARCHAR(64) NULL,
 
    PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE


### PR DESCRIPTION
Issue : For ABQ feature two more fields need to be added in zimba.mobile_devices table.

Fix : Added two more columns as per the description in ZCS-8670. created build and checked that new fields are present.
```
zimbra@ip-172-31-20-17:~$ zmcontrol -v
Release 8.8.15.GA.3031.UBUNTU16.64 UBUNTU16_64 NETWORK edition.
zimbra@ip-172-31-20-17:~$ mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 247
Server version: 10.1.25-MariaDB Zimbra MariaDB binary distribution

Copyright (c) 2000, 2017, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> use zimbra;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
MariaDB [zimbra]> desc mobile_devices;
+----------------------+---------------------+------+-----+---------+-------+
| Field                | Type                | Null | Key | Default | Extra |
+----------------------+---------------------+------+-----+---------+-------+
| mailbox_id           | int(10) unsigned    | NO   | PRI | NULL    |       |
| device_id            | varchar(64)         | NO   | PRI | NULL    |       |
| device_type          | varchar(64)         | NO   |     | NULL    |       |
| user_agent           | varchar(64)         | YES  |     | NULL    |       |
| protocol_version     | varchar(64)         | YES  |     | NULL    |       |
| provisionable        | tinyint(1)          | NO   |     | 0       |       |
| status               | tinyint(3) unsigned | NO   |     | 0       |       |
| policy_key           | int(10) unsigned    | YES  |     | NULL    |       |
| recovery_password    | varchar(64)         | YES  |     | NULL    |       |
| first_req_received   | int(10) unsigned    | NO   |     | NULL    |       |
| last_policy_update   | int(10) unsigned    | YES  |     | NULL    |       |
| remote_wipe_req      | int(10) unsigned    | YES  |     | NULL    |       |
| remote_wipe_ack      | int(10) unsigned    | YES  |     | NULL    |       |
| policy_values        | varchar(512)        | YES  |     | NULL    |       |
| last_used_date       | date                | YES  | MUL | NULL    |       |
| deleted_by_user      | tinyint(1)          | NO   |     | 0       |       |
| model                | varchar(64)         | YES  |     | NULL    |       |
| imei                 | varchar(64)         | YES  |     | NULL    |       |
| friendly_name        | varchar(512)        | YES  |     | NULL    |       |
| os                   | varchar(64)         | YES  |     | NULL    |       |
| os_language          | varchar(64)         | YES  |     | NULL    |       |
| phone_number         | varchar(64)         | YES  |     | NULL    |       |
| unapproved_appl_list | text                | YES  |     | NULL    |       |
| approved_appl_list   | text                | YES  |     | NULL    |       |
| added_to_quarantine  | tinyint(1)          | YES  |     | 0       |       |
| quarantine_status    | text                | YES  |     | NULL    |       |
+----------------------+---------------------+------+-----+---------+-------+
26 rows in set (0.00 sec)
```