### PR TITLE
ZCS-8815 ABQ - update database schema for table abq_devices

### DIFF
--- a/src/db/migration/migrate20200226-MobileDevices.pl
+++ b/src/db/migration/migrate20200226-MobileDevices.pl
@@ -35,6 +35,7 @@ INSERT INTO zimbra.`CONFIG` (name, description, modified)
 CREATE INDEX i_device_id ON mobile_devices (device_id);
   
 CREATE TABLE IF NOT EXISTS zimbra.abq_devices (
+   id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
    device_id       VARCHAR(64) NOT NULL,
    account_id      VARCHAR(127),
    status          ENUM('allowed', 'quarantined', 'blocked'),
@@ -43,9 +44,13 @@ CREATE TABLE IF NOT EXISTS zimbra.abq_devices (
    modified_time   DATETIME,
    modified_by     VARCHAR(255),
 
-   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id),
+   CONSTRAINT pk_abq_devices PRIMARY KEY (id),
    CONSTRAINT fk_abq_devices_device_id FOREIGN KEY (device_id) REFERENCES mobile_devices(device_id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
+
+CREATE INDEX i_device_id ON abq_devices(device_id);
+CREATE INDEX i_account_id ON abq_devices(account_id);
+CREATE INDEX i_status ON abq_devices(status);
 
 _SQL_
 

--- a/src/db/mysql-cluster/db.sql
+++ b/src/db/mysql-cluster/db.sql
@@ -277,6 +277,7 @@ CREATE TABLE current_sessions (
 ) ENGINE = NDBCLUSTER; 
 
 CREATE TABLE abq_devices (
+   id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
    device_id       VARCHAR(64) NOT NULL,
    account_id      VARCHAR(127),
    status          ENUM('allowed', 'quarantined', 'blocked'),
@@ -285,6 +286,10 @@ CREATE TABLE abq_devices (
    modified_time   DATETIME,
    modified_by     VARCHAR(255),
 
-   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id),
+   CONSTRAINT pk_abq_devices PRIMARY KEY (id),
    CONSTRAINT fk_abq_devices_device_id FOREIGN KEY (device_id) REFERENCES mobile_devices(device_id) ON DELETE CASCADE
 ) ENGINE = NDBCLUSTER;
+
+CREATE INDEX i_device_id ON abq_devices(device_id);
+CREATE INDEX i_account_id ON abq_devices(account_id);
+CREATE INDEX i_status ON abq_devices(status);

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -465,6 +465,7 @@ CREATE TABLE `chat`.`CONVERSATION_OPTIONS` (
 ) ENGINE = InnoDB;
 
 CREATE TABLE abq_devices (
+   id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
    device_id       VARCHAR(64) NOT NULL,
    account_id      VARCHAR(127),
    status          ENUM('allowed', 'quarantined', 'blocked'),
@@ -473,10 +474,10 @@ CREATE TABLE abq_devices (
    modified_time   DATETIME,
    modified_by     VARCHAR(255),
 
-   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id),
+   CONSTRAINT pk_abq_devices PRIMARY KEY (id),
    CONSTRAINT fk_abq_devices_device_id FOREIGN KEY (device_id) REFERENCES mobile_devices(device_id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
-CREATE INDEX `INDEX_CONVERSATION_OPTIONS` ON `chat`.`CONVERSATION_OPTIONS` (`ACCOUNT_ID`,`ADDRESS`);
-CREATE INDEX `INDEX_CONVERSATION_OPTIONS_ACCOUNT_ID` ON `chat`.`CONVERSATION_OPTIONS` (`ACCOUNT_ID`);
-CREATE INDEX `INDEX_CONVERSATION_OPTIONS_ADDRESS` ON `chat`.`CONVERSATION_OPTIONS` (`ADDRESS`);
+CREATE INDEX i_device_id ON abq_devices(device_id);
+CREATE INDEX i_account_id ON abq_devices(account_id);
+CREATE INDEX i_status ON abq_devices(status);

--- a/src/db/sqlite/db.sql
+++ b/src/db/sqlite/db.sql
@@ -163,6 +163,7 @@ CREATE TABLE mobile_devices (
 );
 
 CREATE TABLE abq_devices (
+   id              INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
    device_id       VARCHAR(64) NOT NULL,
    account_id      VARCHAR(127),
    status          ENUM('allowed', 'quarantined', 'blocked'),
@@ -171,8 +172,11 @@ CREATE TABLE abq_devices (
    modified_time   DATETIME,
    modified_by     VARCHAR(255),
 
-   CONSTRAINT pk_abq_devices PRIMARY KEY (device_id),
+   CONSTRAINT pk_abq_devices PRIMARY KEY (id),
    CONSTRAINT fk_abq_devices_device_id FOREIGN KEY (device_id) REFERENCES mobile_devices(device_id) ON DELETE CASCADE
 );
 
+CREATE INDEX i_device_id ON abq_devices(device_id);
+CREATE INDEX i_account_id ON abq_devices(account_id);
+CREATE INDEX i_status ON abq_devices(status);
 CREATE INDEX i_mobile_devices_last_used_date ON mobile_devices(last_used_date);


### PR DESCRIPTION
Issue:  we can't keep the device along with account entries in the database.

Fix: 
Remove the existing primary key from field device_id and create a new field with name 'id' AUTO_INCREMENT as a primary key. Add Index on fields device_id, account_id, and status
Removed duplicate Index code for chat table.

Testing is done:
- Created a new build on branch bugfix/ZCS-8815 on "zm-mailbox" and "zm-db-conf" repos
- Installed the build and verified the DB changes by connecting to MySQL DB.
- Added more details in the ticket

