### PR TITLE
ZCS-10388 EAS - Bring 16.0/16.1 support to z9

### DIFF
--- a/src/db/migration/migrate20200625-MobileDevices.pl
+++ b/src/db/migration/migrate20200625-MobileDevices.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2020 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+
+use strict;
+use Migrate;
+
+Migrate::verifySchemaVersion(115);
+
+addMobileOperatorColumn();
+
+Migrate::updateSchemaVersion(115, 116);
+
+exit(0);
+
+#####################
+
+sub addMobileOperatorColumn() {
+    my $sql = <<MOBILE_DEVICES_ADD_COLUMN_EOF;
+ALTER TABLE mobile_devices ADD COLUMN mobile_operator VARCHAR(512);
+MOBILE_DEVICES_ADD_COLUMN_EOF
+
+    Migrate::log("Adding mobile_operator column to ZIMBRA.MOBILE_DEVICES table.");
+    Migrate::runSql($sql);
+}

--- a/src/db/migration/migrate20210319-MobileDevices.pl
+++ b/src/db/migration/migrate20210319-MobileDevices.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2020 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+#
+
+
+use strict;
+use Migrate;
+
+Migrate::verifySchemaVersion(117);
+
+addLastUpdatedByColumn();
+
+Migrate::updateSchemaVersion(117, 118);
+
+exit(0);
+
+#####################
+
+sub addLastUpdatedByColumn() {
+    my $sql = <<MOBILE_DEVICES_ADD_COLUMN_EOF;
+ALTER TABLE mobile_devices ADD COLUMN last_updated_by ENUM('Admin','User') DEFAULT 'User';
+MOBILE_DEVICES_ADD_COLUMN_EOF
+
+    Migrate::log("Adding last_updated_by column to ZIMBRA.MOBILE_DEVICES table.");
+    Migrate::runSql($sql);
+}

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -243,7 +243,8 @@ CREATE TABLE mobile_devices (
    phone_number        VARCHAR(64),
    unapproved_appl_list TEXT NULL,
    approved_appl_list   TEXT NULL,
-   
+   mobile_operator      VARCHAR(512),
+
    PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,
    INDEX i_last_used_date (last_used_date)

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -244,7 +244,8 @@ CREATE TABLE mobile_devices (
    unapproved_appl_list TEXT NULL,
    approved_appl_list   TEXT NULL,
    mobile_operator      VARCHAR(512),
-
+   last_updated_by     ENUM('Admin','User') DEFAULT 'Admin',
+   
    PRIMARY KEY (mailbox_id, device_id),
    CONSTRAINT fk_mobile_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES mailbox(id) ON DELETE CASCADE,
    INDEX i_last_used_date (last_used_date)


### PR DESCRIPTION
bringing eas and abq from zx to z9

branch `eas_zx` is used for below repositories
1. zm-mailbox
2. zm-sync-common
3. zm-sync-store
4. zm-sync-client
5. zm-sync-tools
6. zm-db-conf
7. zm-build

**Testing done:**
- Environment is setup on `zdev-vm003.eng.zimbra.com`
- Verified abq and eas changes by configuring account on ipad

**Testing to be done by QA:**
- Verify eas 16.0/16.1 changes
- Verify recent abq changes
- Verify eas 12.1 and 14.1 by changing localconfig `zimbra_activesync_versions`