### PR TITLE
ZCS-10498: Integrate Briefcase related APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+.classpath
+.project

--- a/src/db/mysql/create_database.sql
+++ b/src/db/mysql/create_database.sql
@@ -302,3 +302,25 @@ CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.purged_messages (
    PRIMARY KEY (mailbox_id, data_source_id, item_id),
    CONSTRAINT fk_purged_message_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.event (
+   mailbox_id    INTEGER UNSIGNED NOT NULL,
+   account_id    VARCHAR(36) NOT NULL,  -- user performing the action (email address or guid)
+   item_id       INTEGER NOT NULL,  -- itemId for the event
+   folder_id     INTEGER NOT NULL,  -- folderId for the item in the event
+   op            TINYINT NOT NULL,  -- operation
+   ts            INTEGER NOT NULL,  -- timestamp
+   version       INTEGER,           -- version of the item
+   user_agent    VARCHAR(128),      -- identifier of device if available
+   arg           VARCHAR(10240),    -- operation specific argument
+
+   CONSTRAINT fk_event_mailbox_id FOREIGN KEY (mailbox_id) REFERENCES zimbra.mailbox(id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.watch (
+   mailbox_id   INTEGER UNSIGNED NOT NULL,
+   target       VARCHAR(36) NOT NULL,  -- watch target account id
+   item_id      INTEGER NOT NULL,  -- target item id
+
+   PRIMARY KEY (mailbox_id, target, item_id)
+) ENGINE = InnoDB;


### PR DESCRIPTION
Back port changes from ZimbraX to Zimbra9 for Briefcase APIs and update recently viewed documents.
This includes changes back ported from ZCS-9144, ZCS-9445, ZCS-9933, ZCS-9807, ZCS-10002

https://github.com/Zimbra/zm-doc-server-ext/pull/1
https://github.com/Zimbra/zm-mailbox/pull/1140