### PR TITLE
ZCS-11842 adding FileBlobStore as default store manager

### DIFF
--- a/src/db/migration/migrate20220525-Volume.pl
+++ b/src/db/migration/migrate20220525-Volume.pl
@@ -63,7 +63,7 @@ VOLUME_ADD_COLUMN_EOF
 # Function to add 'store_manager_class' column
 sub addStoreManagerClassColumn() {
     my $sql = <<VOLUME_ADD_COLUMN_EOF;
-ALTER TABLE volume ADD COLUMN IF NOT EXISTS store_manager_class VARCHAR(255) DEFAULT NULL;
+ALTER TABLE volume ADD COLUMN IF NOT EXISTS store_manager_class VARCHAR(255) DEFAULT 'com.zimbra.cs.store.file.FileBlobStore';
 VOLUME_ADD_COLUMN_EOF
 
     Migrate::log("Adding store_manager_class column to zimbra.volume table.");

--- a/src/db/mysql/db.sql
+++ b/src/db/mysql/db.sql
@@ -51,7 +51,7 @@ CREATE TABLE volume (
    compression_threshold  BIGINT NOT NULL,
    metadata               MEDIUMTEXT,
    store_type             TINYINT(1) NOT NULL DEFAULT 1, -- 1 for INTERNAL(onstore) and 2 for EXTERNAL(s3 bucket, OPENIO)
-   store_manager_class    VARCHAR(255) DEFAULT NULL,
+   store_manager_class    VARCHAR(255) DEFAULT 'com.zimbra.cs.store.file.FileBlobStore',
 
    UNIQUE INDEX i_name (name),
    UNIQUE INDEX i_path (path(255))   -- Index prefix length of 255 is the max prior to MySQL 4.1.2.  Should be good enough.


### PR DESCRIPTION
Description:
The new column store_manager_class has been introduced in zimbra.volume table to map respective store manager to volume in case there is different implementation available for volumes. 
For now adding 'com.zimbra.cs.store.file.FileBlobStore' as default store manager class