### PR TITLE
ZCS-15017 : script to manually upgrade the database schema and skip update (FilesShareWithMeFolder.pl) for orphan accounts

### DIFF
--- a/src/db/migration/migrate20220729-FilesShareWithMeFolder.pl
+++ b/src/db/migration/migrate20220729-FilesShareWithMeFolder.pl
@@ -92,7 +92,7 @@ SELECT
     '$foldername', '$foldername', '$metadata',
     change_checkpoint, $now, change_checkpoint
 FROM mailbox
-WHERE group_id = $gid
+WHERE group_id = $gid AND id IN (SELECT DISTINCT(mailbox_id) FROM mboxgroup$gid.mail_item)
 ON DUPLICATE KEY UPDATE name = '$foldername';
 _SQL_
     return $sql;

--- a/src/db/migration/zmdbupgrade.pl
+++ b/src/db/migration/zmdbupgrade.pl
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+use strict;
+use lib "/opt/zimbra/libexec";
+use lib "/opt/zimbra/libexec/scripts";
+use lib "/opt/zimbra/common/lib/perl5";
+use Migrate;
+use zmupgrade;
+
+my $platform = qx(/opt/zimbra/libexec/get_plat_tag.sh);
+chomp $platform;
+my $su = "su - zimbra -c";
+my $hiVersion = 118;
+
+sub progress {
+	my $msg = shift;
+	print "$msg";
+}
+
+sub isInstalled {
+	my $pkg = shift;
+	my $pkgQuery;
+	my $good = 0;
+	if ($platform =~ /^DEBIAN/ || $platform =~ /^UBUNTU/) {
+		$pkgQuery = "dpkg -s $pkg";
+	} else {
+		$pkgQuery = "rpm -q $pkg";
+	}
+
+	my $rc = 0xffff & system ("$pkgQuery > /dev/null 2>&1");
+	$rc >>= 8;
+	if (($platform =~ /^DEBIAN/ || $platform =~ /^UBUNTU/) && $rc == 0 ) {
+		$good = 1;
+		$pkgQuery = "dpkg -s $pkg | egrep '^Status: ' | grep 'not-installed'";
+		$rc = 0xffff & system ("$pkgQuery > /dev/null 2>&1");
+		$rc >>= 8;
+		return ($rc == $good);
+	} else {
+		return ($rc == $good);
+	}
+}
+
+sub runAsZimbra {
+	my $cmd = shift;
+	progress("*** Running as zimbra user: $cmd\n");
+	my $rc;
+	$rc = 0xffff & system("$su \"$cmd\"");
+	return $rc;
+}
+
+
+sub main {
+	my $curSchemaVersion;
+	if (isInstalled("zimbra-store")) {
+		my $startSqlResult = zmupgrade::startSql();
+		if ($startSqlResult != 0) {
+			progress("Failed to start MySQL. Exiting.\n");
+			exit 1;
+		}
+		$curSchemaVersion = Migrate::getSchemaVersion();
+		if ($curSchemaVersion < $hiVersion) {
+			progress("Schema upgrade required from version $curSchemaVersion to $hiVersion.\n");
+			while ($curSchemaVersion < $hiVersion) {
+				if (zmupgrade::runSchemaUpgrade($curSchemaVersion)) {
+					progress("Schema upgrade failed. Exiting.\n");
+					exit 1;
+				}
+				$curSchemaVersion = Migrate::getSchemaVersion();
+			}
+			progress("Schema upgrade completed successfully.\n");
+		} else {
+			progress("Schema upgrade not required.\n");
+		}
+	}
+	return 0;
+}
+exit main();


### PR DESCRIPTION
Script `/opt/zimbra/libexec/scripts/zmdbupgrade.pl` to manually upgrade the database schema in case there’s an issue like below.
```
2024-02-11 23:30:40,469 INFO  [main] [] system - Setting mysql connector property: maxActive=100
2024-02-11 23:30:40,552 ERROR [main] [] Versions - DB Version Mismatch: ours=118 from DB=111
2024-02-11 23:30:40,552 FATAL [main] [] system - Data version mismatch.  Reinitialize or upgrade the backend data store.
```
skip update (FilesShareWithMeFolder.pl) for orphan accounts

https://github.com/Zimbra/zm-build/pull/278